### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.0.0 (2022-05-09)
+==================
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed

--- a/djangocms_fil_bootstrap/__init__.py
+++ b/djangocms_fil_bootstrap/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.13"
+__version__ = "1.0.0"
 
 __all__ = ["bootstrap"]
 


### PR DESCRIPTION
* Python 3.8, 3.9 support added
* Django 3.0, 3.1 and 3.2 support added
* Python 3.5 and 3.6 support removed
* Django 1.11 support removed